### PR TITLE
write actual (not padded) length in sfnt directory; set OS/2 to version 1; add required fields in 'post'

### DIFF
--- a/fontgenerator.js
+++ b/fontgenerator.js
@@ -431,8 +431,9 @@ TinyFontGenerator = {
     var data = ""; 
     data += " 00 01 00 00";  // version 1
     data += " 00 00 00 00";  // italicAngle
-    data += " 00 00 00 00";  // underlinePosition
-    data += " 00 00 00 00";  // underlineThickness
+    data += " 00 00";        // underlinePosition
+    data += " 00 00";        // underlineThickness
+    data += " 00 00 00 00";  // isFixedPitch
     this.POSTdata = this.convertData(data);
     return this.POSTdata;
   },

--- a/fontgenerator.js
+++ b/fontgenerator.js
@@ -80,8 +80,6 @@ TinyFontGenerator = {
     // convert from string to byte code
     for(var bt=0, e=data.length; bt<e; bt++) {
       buffer += this.asByte(data[bt].trim()); }
-    // ensure the data is long-aligned
-    while(buffer.length%4!=0) { buffer += this.chr(0); }
     // return the bytecode data
     return buffer;
   },
@@ -481,12 +479,15 @@ TinyFontGenerator = {
         len;                       // iteration value
     for(var i=0; i<olen; i++) {
       tablename = ordering[i];
+      // table directory should record the table's actual (not padded) length
       len = tables[tablename].length;
+      // the table data itself should be long-aligned
+      while(tables[tablename].length % 4 != 0) { tables[tablename] += this.chr(0); }
       font += tablename;
       font += this.computeChecksum(tables[tablename]);  // table checksum
       font += this.toULONG(offset);                     // offset for this table
       font += this.toULONG(len);                        // table length
-      offset += len;
+      offset += tables[tablename].length;
     }
 
     // Finally, write the actual table data blocks


### PR DESCRIPTION
Hi,

I was trying your fontgenerator.js (to make a minimal font to use for fonttools' unit tests) and I noticed a few things which might be fixed. 

The reason OTS complains about the OS/2 table version (see https://github.com/Pomax/Minimal-font-generator/issues/1) is because the version 4 requires additional fields which you didn't include, such as `sxHeight` and others, as specified here:
https://www.microsoft.com/typography/otspec/os2ver4.htm

If you want to only keep the ones you specified, then you need to set the OS/2 table version to 1.
https://www.microsoft.com/typography/otspec/os2ver1.htm

Also, the post table's header is missing some required fields such as `isFixedPitch` etc., which might be useless in practice, but still the spec requires them, and a compliant sfnt reader should refuse to load the font if they are missing.
https://www.microsoft.com/typography/otspec/post.htm
https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6post.html

Finally, the OpenType font file specification says that

> The length of all tables should be recorded in the table record with their actual length (not their padded length).
> https://www.microsoft.com/typography/otspec/otff.htm

You fontgenerator.js writes instead the padded table length in the sfnt directory. You have store the actual lengths and pad the table data so that their offsets are long-aligned.

Mind that I'm not a javascript programmer, so feel free to apply the changes manually if you prefer.

Cheers!

Cosimo
